### PR TITLE
Fix importing images on firefox web browser

### DIFF
--- a/frontend/src/pages/Editor.jsx
+++ b/frontend/src/pages/Editor.jsx
@@ -74,6 +74,15 @@ const Editor = () => {
     const files = target.files;
     // get the first image selected by file-picker
     const base64 = await toBase64(files[0]);
+    const type = files[0].type;
+    const size = files[0].size;
+    const name = files[0].name;
+    console.log('loading file:', name, type, size);
+
+    if(files[0].type.substring(0,5) != "image") {
+      alert("Invalid file type. Please select an image file.");
+      return;
+    }
 
     // now process it into the canvas if possible
 
@@ -125,6 +134,12 @@ const Editor = () => {
     const files = target.files;
     // get the first image selected by file-picker
     // console.log(files[0]);
+
+    if(files[0].type !== "application/json") {
+      alert("Invalid file type. Please select a JSON file.");
+      return;
+    }
+
     try {
       const reader = new FileReader();
       reader.onload = function (e) {

--- a/frontend/src/pages/Editor.jsx
+++ b/frontend/src/pages/Editor.jsx
@@ -87,6 +87,7 @@ const Editor = () => {
     // now process it into the canvas if possible
 
     var img = new Image();
+    // img.crossOrigin = "Anonymous"; // Enable CORS so firefox will be nice
     img.onload = function () {
       console.log('loading image');
       // create a temporary canvas element not on the dom for processing the image
@@ -99,7 +100,14 @@ const Editor = () => {
       try {
         // might throw
         console.log(`new canvas width and height ${tmpCanvas.width}, ${tmpCanvas.height}`);
-        const simp = new SimpleImage({ imageData: ctx.getImageData(0, 0, tmpCanvas.width, tmpCanvas.height) });
+        const imageData = ctx.getImageData(0, 0, tmpCanvas.width, tmpCanvas.height);
+        console.log('image data:', imageData);
+        if(!imageData) {
+          console.error('failed to load image data');
+          alert('image load failed. Likely due to CORS policy blocking the image.');
+          return;
+        }
+        const simp = new SimpleImage({ imageData });
         // this applies the k-means clustering centroid based downscaling algorithm to the image with 4 buckets and 10 iterations
         let { kCentroid } = DownScaler.kCenter(simp, canvasData.width, canvasData.height, 4, 10);
 

--- a/frontend/src/utils/SimpleImage.js
+++ b/frontend/src/utils/SimpleImage.js
@@ -49,8 +49,11 @@ class SimpleImage {
         }
 
         // otherwise we try and load an srgb image
-        if (!imageData || imageData.colorSpace != "srgb") {
-            throw new Error(`must provide a valid srgb ImageData to SimpleImage. Tried ${imageData}`);
+        if (
+            !imageData
+            // || imageData.colorSpace != "srgb" // we are disabling this restriction for now due to firefox being different
+        ) {
+            throw new Error(`must provide a valid srgb ImageData to SimpleImage. Tried ${imageData.colorSpace} ${JSON.stringify(imageData)}`);
         }
         if (imageData.width == null || imageData.height == null || imageData.width <= 0 || imageData.height <= 0) {
             throw new Error("image data dimensions were invalid");


### PR DESCRIPTION
image data from file picker on Firefox does not have a color space field, so we are just omitting the check for now for compatibility.