### PR TITLE
Fixing the image details overlay

### DIFF
--- a/frontend/src/components/GalleryPageComponents/ImageDetailsOverlay.jsx
+++ b/frontend/src/components/GalleryPageComponents/ImageDetailsOverlay.jsx
@@ -5,6 +5,9 @@ import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import WhatsAppIcon from "@mui/icons-material/WhatsApp";
 import FacebookIcon from "@mui/icons-material/Facebook";
 import TwitterIcon from "@mui/icons-material/Twitter";
+import { CiLink } from "react-icons/ci";
+import { FaEdit } from "react-icons/fa";
+import { IoIosDownload } from "react-icons/io";
 import "../../css/GalleryPageCSS/ImageDetailsOverlay.css";
 
 function ImageDetailsOverlay() {
@@ -83,9 +86,12 @@ function ImageDetailsOverlay() {
                         <a href={`https://twitter.com/intent/tweet?url=${image.imgDataUrl}`} target="_blank" rel="noopener noreferrer">
                             <TwitterIcon />
                         </a>
-                        <button onClick={copyToClipboard}>{copied ? "Copied!" : "Copy URL"}</button>
-                        <button onClick={downloadImage}>Download</button>
-                        <button onClick={editImage}>Edit</button>
+                        <div className="tooltip">
+                            <button onClick={copyToClipboard}><CiLink /></button>
+                            <span className={`tooltiptext ${copied ? 'show' : ''}`}>Copied!</span>
+                        </div>
+                        <button onClick={downloadImage}><IoIosDownload /></button>
+                        <button onClick={editImage}><FaEdit /></button>
                     </div>
                 </div>
             </div>

--- a/frontend/src/css/GalleryPageCSS/ImageDetailsOverlay.css
+++ b/frontend/src/css/GalleryPageCSS/ImageDetailsOverlay.css
@@ -8,7 +8,8 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.7); /* Dark background overlay */
+    background-color: rgba(0, 0, 0, 0.7);
+    /* Dark background overlay */
     z-index: 1000;
 }
 
@@ -84,6 +85,9 @@
 .share_links {
     display: flex;
     gap: 15px;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-evenly;
 }
 
 .share_links a {
@@ -94,6 +98,13 @@
 
 .share_links a:hover {
     color: #005f8a;
+}
+
+.share_links button {
+    /* align text and icons together nicely */
+    display: flex;
+    align-items: center;
+    gap: 0.2em;
 }
 
 .download_btn {
@@ -121,6 +132,33 @@
     z-index: 2000;
 }
 
+.tooltip {
+    position: relative;
+    display: inline-flex;
+}
+
+.tooltip .tooltiptext {
+    visibility: hidden;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 10px;
+    position: absolute;
+    z-index: 42;
+    bottom: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 0;
+    transition: opacity 0.3s;
+    user-select: none;
+}
+
+.tooltip .tooltiptext.show {
+    visibility: visible;
+    opacity: 1;
+}
+
 @media screen and (max-width: 768px) {
     .content {
         flex-direction: column;
@@ -130,6 +168,7 @@
     .image_section {
         padding-right: 0;
     }
+
     .image_section img {
         width: auto;
         height: 20vh;


### PR DESCRIPTION
Fixed the design of the image details overlay for mobile. The text alignment issue was caused by the share icons not wrapping. I also made the buttons smaller using icons instead of text