### PR TITLE
fixed safari mobile zoom in caused by input text smaller than 1 rem o…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>Pixel AI</title>
   </head>
   <body>

--- a/frontend/src/css/NewImagePopup.css
+++ b/frontend/src/css/NewImagePopup.css
@@ -42,7 +42,7 @@
   padding: 8px;
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
-  font-size: 0.9rem;
+  font-size: 1rem;
   margin-bottom: 15px;
 }
 

--- a/frontend/src/css/SaveImagePopup.css
+++ b/frontend/src/css/SaveImagePopup.css
@@ -40,7 +40,7 @@
   padding: 8px;
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
-  font-size: 0.9rem;
+  font-size: 1rem;
   margin-bottom: 15px;
 }
 

--- a/frontend/src/css/ShareImagePopup.css
+++ b/frontend/src/css/ShareImagePopup.css
@@ -42,7 +42,7 @@
     padding: 8px;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
-    font-size: 0.9rem;
+    font-size: 1rem;
     margin-bottom: 15px;
   }
   

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -78,3 +78,7 @@ h1 {
     background: var(--overlay-bg-dark);
   }
 }
+/* default the text input font size to at least 16px to prevent safari zoom in */
+input[type="text"] {
+  font-size: 16px;
+}


### PR DESCRIPTION
As documented here: https://www.telerik.com/products/aspnet-ajax/documentation/knowledge-base/common-disable-autozoom-input-safari-iphone

safari mobile automatically zooms in on click to text boxes with font size smaller than 16px (or 1rem).

This pr fixes it in two ways. max-scale and font size